### PR TITLE
Fix Esperanto exports using a defineProperty

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,3 +1,5 @@
-import DynamicComponentView from './views/dynamic-component';
+import DCV from './views/dynamic-component';
+
+var DynamicComponentView = DCV;
 
 export { DynamicComponentView };


### PR DESCRIPTION
This change avoid a feature/bug in esperanto using `Object.defineProperty` for the export. `Object.defineProperty` does not work in IE8 in every object, only in DOM nodes.

I understand this is not this code's fault but it is a workaround until this gets fixed in esperanto/ember-cli.
